### PR TITLE
Some minor adjustments

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -97,9 +97,6 @@ fn main() {
     let mut r = Runner::new(&ROOT_MENU, &mut buffer, Output(window));
     loop {
         match r.context.0.getch() {
-            Some(Input::Character('\n')) => {
-                r.input_byte(b'\r');
-            }
             Some(Input::Character(c)) => {
                 let mut buf = [0; 4];
                 for b in c.encode_utf8(&mut buf).bytes() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,14 +509,14 @@ where
                 }
             }
             ItemType::Menu(_menu) => {
-                write!(self.context, "  {}", item.command).unwrap();
+                writeln!(self.context, "  {}\n", item.command).unwrap();
             }
             ItemType::_Dummy => {
-                write!(self.context, "  {}", item.command).unwrap();
+                writeln!(self.context, "  {}\n", item.command).unwrap();
             }
         }
         if let Some(help) = item.help {
-            writeln!(self.context, "\n\nDESCRIPTION:\n{}", help).unwrap();
+            writeln!(self.context, "DESCRIPTION:\n{}", help).unwrap();
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,8 +379,6 @@ where
                         writeln!(self.context, "Command {:?} not found. Try 'help'.", cmd).unwrap();
                     }
                 }
-            } else {
-                writeln!(self.context, "Input was empty?").unwrap();
             }
         } else {
             // Hmm ..  we did not have a valid string

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,21 +295,7 @@ where
         } else if self.used < self.buffer.len() {
             self.buffer[self.used] = input;
             self.used += 1;
-
-            // We have to do this song and dance because `self.prompt()` needs
-            // a mutable reference to self, and we can't have that while
-            // holding a reference to the buffer at the same time.
-            // This line grabs the buffer, checks it's OK, then releases it again
-            let valid = core::str::from_utf8(&self.buffer[0..self.used]).is_ok();
-            // Now we've released the buffer, we can draw the prompt
-            if valid {
-                write!(self.context, "\r").unwrap();
-                self.prompt(false);
-            }
-            // Grab the buffer again to render it to the screen
-            if let Ok(s) = core::str::from_utf8(&self.buffer[0..self.used]) {
-                write!(self.context, "{}", s).unwrap();
-            }
+            write!(self.context, "{}", input as char).unwrap();
             Outcome::NeedMore
         } else {
             writeln!(self.context, "Buffer overflow!").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,11 +277,7 @@ where
     /// carriage-return, the buffer is scanned and the appropriate action
     /// performed.
     pub fn input_byte(&mut self, input: u8) {
-        // Strip carriage returns
-        if input == 0x0A {
-            return;
-        }
-        let outcome = if input == 0x0D {
+        let outcome = if input == 0x0D || input == 0x0A {
             // Handle the command
             self.process_command();
             Outcome::CommandProcessed


### PR DESCRIPTION
This could be a breaking change depending on how this library is used, but I still think these changes make it more usable, and should be easy to adjust for as a user if needed (just don't call `input_byte` when receiving line feed if you still want the old behaviour).

As for the change regarding the output "song and dance", I'm not sure if I'm missing something, or if it's just overly complicated. Also the old solution does not work well with terminals like Cutecom, which ignore carriage return.