### PR TITLE
Feature gate local echo.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ readme = "README.md"
 
 
 [features]
-no-echo = []
+default = ["echo"]
+echo = []
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,9 @@ readme = "README.md"
 [dependencies]
 
 
+[features]
+no-echo = []
+
+
 [dev-dependencies]
 pancurses = "0.16"

--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ It contains multiple paragraphs and should be preceeded by the parameter list.
 
 * None
 
+### v0.3.3
+
+* Add the possibility to disable local echo (via echo feature, enabled by default)
+
 ### v0.3.2
 
 * Shortened help output.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,7 @@ where
             return;
         }
         let outcome = if input == 0x0D {
-            #[cfg(feature = "no-echo")]
+            #[cfg(not(feature = "echo"))]
             {
                 // Echo the command
                 write!(self.context, "\r").unwrap();
@@ -304,7 +304,7 @@ where
             self.buffer[self.used] = input;
             self.used += 1;
 
-            #[cfg(not(feature = "no-echo"))]
+            #[cfg(feature = "echo")]
             {
                 // We have to do this song and dance because `self.prompt()` needs
                 // a mutable reference to self, and we can't have that while

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,6 +276,7 @@ where
     /// Add a byte to the menu runner's buffer. If this byte is a
     /// carriage-return, the buffer is scanned and the appropriate action
     /// performed.
+    /// By default, an echo feature is enabled to display commands on the terminal.
     pub fn input_byte(&mut self, input: u8) {
         // Strip carriage returns
         if input == 0x0A {


### PR DESCRIPTION
Hello!

I'd like to propose adding a feature gate that disables local echo.

To implement this, I've added a new `no-echo` feature flag to the `Cargo.toml` file and wrapped the relevant code in an `#[cfg(not(feature = "no-echo"))]` block. I've also added code to write the whole command after a carriage-return is a sent. This is wrapped in an `#[cfg(feature = "no-echo")]`.

I believe this feature will be useful for users who want to disable local echo in certain cases (when using menu with RTT transport for ex.). Please let me know if you have any questions or concerns.

Thank you!