### PR TITLE
Taking ownership of menu in runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,20 @@
+name: Rust
+
+on: [push, pull_request]
+
+jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Check formatting
+      run: cargo fmt -- --check
+
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build
+      run: cargo build
+    - name: Run Tests
+      run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.3.2"
 authors = ["Jonathan 'theJPster' Pallant <github@thejpster.org.uk>"]
 description = "A simple #[no_std] command line interface."
 license = "MIT OR Apache-2.0"
-edition = "2018"
-repository = "https://github.com/thejpster/menu"
+edition = "2021"
+repository = "https://github.com/rust-embedded-community/menu"
 readme = "README.md"
 
 [dependencies]
@@ -14,7 +14,6 @@ readme = "README.md"
 [features]
 default = ["echo"]
 echo = []
-
 
 [dev-dependencies]
 pancurses = "0.16"

--- a/README.md
+++ b/README.md
@@ -169,10 +169,8 @@ It contains multiple paragraphs and should be preceeded by the parameter list.
 
 ### Unreleased changes
 
-* None
-
-### v0.3.3
-
+* Changed the `struct Runner` to own the `struct Menu` instead of borrowing it.
+* Made `struct Menu` implement `Clone`
 * Add the possibility to disable local echo (via echo feature, enabled by default)
 
 ### v0.3.2

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -94,7 +94,7 @@ fn main() {
     window.scrollok(true);
     noecho();
     let mut buffer = [0u8; 64];
-    let mut r = Runner::new(&ROOT_MENU, &mut buffer, Output(window));
+    let mut r = Runner::new(ROOT_MENU, &mut buffer, Output(window));
     loop {
         match r.context.0.getch() {
             Some(Input::Character('\n')) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ where
 {
     buffer: &'a mut [u8],
     used: usize,
-    menu: menu_manager::MenuManager<'a, T>,
+    menu_mgr: menu_manager::MenuManager<'a, T>,
 
     /// The context object the `Runner` carries around.
     pub context: T,
@@ -256,7 +256,7 @@ where
             cb_fn(&menu, &mut context);
         }
         let mut r = Runner {
-            menu: menu_manager::MenuManager::new(menu),
+            menu_mgr: menu_manager::MenuManager::new(menu),
             buffer,
             used: 0,
             context,
@@ -271,12 +271,12 @@ where
         if newline {
             writeln!(self.context).unwrap();
         }
-        for i in 0..self.menu.depth() {
+        for i in 0..self.menu_mgr.depth() {
             if i > 1 {
                 write!(self.context, "/").unwrap();
             }
 
-            let menu = self.menu.get_menu(Some(i));
+            let menu = self.menu_mgr.get_menu(Some(i));
             write!(self.context, "/{}", menu.label).unwrap();
         }
         write!(self.context, "> ").unwrap();
@@ -353,7 +353,7 @@ where
             // We have a valid string
             let mut parts = command_line.split_whitespace();
             if let Some(cmd) = parts.next() {
-                let menu = self.menu.get_menu(None);
+                let menu = self.menu_mgr.get_menu(None);
                 if cmd == "help" {
                     match parts.next() {
                         Some(arg) => match menu.items.iter().find(|i| i.command == arg) {
@@ -369,7 +369,7 @@ where
                             for item in menu.items {
                                 self.print_short_help(&item);
                             }
-                            if self.menu.depth() != 0 {
+                            if self.menu_mgr.depth() != 0 {
                                 self.print_short_help(&Item {
                                     command: "exit",
                                     help: Some("Leave this menu."),
@@ -383,11 +383,11 @@ where
                             });
                         }
                     }
-                } else if cmd == "exit" && self.menu.depth() != 0 {
+                } else if cmd == "exit" && self.menu_mgr.depth() != 0 {
                     if let Some(cb_fn) = menu.exit {
                         cb_fn(menu, &mut self.context);
                     }
-                    self.menu.pop_menu();
+                    self.menu_mgr.pop_menu();
                 } else {
                     let mut found = false;
                     for (i, item) in menu.items.iter().enumerate() {
@@ -405,10 +405,10 @@ where
                                     command_line,
                                 ),
                                 ItemType::Menu(_) => {
-                                    if let Some(cb_fn) = self.menu.get_menu(None).entry {
+                                    if let Some(cb_fn) = self.menu_mgr.get_menu(None).entry {
                                         cb_fn(menu, &mut self.context);
                                     }
-                                    self.menu.push_menu(i);
+                                    self.menu_mgr.push_menu(i);
                                 }
                                 ItemType::_Dummy => {
                                     unreachable!();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,6 +232,17 @@ enum Outcome {
     NeedMore,
 }
 
+impl<'a, T> core::clone::Clone for Menu<'a, T> {
+    fn clone(&self) -> Menu<'a, T> {
+        Menu {
+            label: self.label,
+            items: self.items,
+            entry: self.entry,
+            exit: self.exit,
+        }
+    }
+}
+
 impl<'a, T> Runner<'a, T>
 where
     T: core::fmt::Write,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,7 +377,6 @@ where
                         cb_fn(menu, &mut self.context);
                     }
                     self.menu.pop_menu();
-
                 } else {
                     let mut found = false;
                     for (i, item) in menu.items.iter().enumerate() {
@@ -395,9 +394,7 @@ where
                                     command_line,
                                 ),
                                 ItemType::Menu(_) => {
-
-                                    if let Some(cb_fn) = self.menu.get_menu(None).entry
-                                    {
+                                    if let Some(cb_fn) = self.menu.get_menu(None).entry {
                                         cb_fn(menu, &mut self.context);
                                     }
                                     self.menu.push_menu(i);

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -1,0 +1,54 @@
+use super::{Menu, ItemType};
+
+pub struct MenuManager<'a, T> {
+    menu: Menu<'a, T>,
+    /// Maximum four levels deep
+    menu_index: [Option<usize>; 4],
+}
+
+impl <'a, T> MenuManager<'a, T> {
+    pub fn new(menu: Menu<'a, T>) -> Self {
+        Self {
+            menu,
+            menu_index: [None, None, None, None],
+        }
+    }
+
+    pub fn depth(&self) -> usize {
+        self.menu_index.iter().take_while(|x| x.is_some()).count()
+    }
+
+    pub fn pop_menu(&mut self) {
+        if let Some(pos) = self.menu_index.iter_mut().rev().skip_while(|x| x.is_none()).next() {
+            pos.take();
+        }
+    }
+
+    pub fn push_menu(&mut self, index: usize) {
+        let menu = self.get_menu(None);
+        let item = menu.items[index];
+        if !matches!(item.item_type, ItemType::Menu(_)) {
+            panic!("Specified index is not a menu");
+        }
+
+        let pos = self.menu_index.iter_mut().skip_while(|x| x.is_some()).next().unwrap();
+        pos.replace(index);
+    }
+
+    pub fn get_menu(&self, depth: Option<usize>) -> &Menu<'a, T> {
+        let mut menu = &self.menu;
+
+        let depth = depth.unwrap_or_else(|| self.depth());
+
+        for position in self.menu_index.iter().take_while(|x| x.is_some()).map(|x| x.unwrap()).take(depth) {
+            if let ItemType::Menu(m) = menu.items[position].item_type {
+                menu = m
+            } else {
+                panic!("Selected item is not a menu");
+            }
+        }
+
+        menu
+    }
+
+}

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -1,5 +1,10 @@
+//! The Menu Manager looks after the menu and where we currently are within it.
+#![deny(missing_docs)]
+
 use super::{ItemType, Menu};
 
+/// Holds a nested tree of Menus and remembers which menu within the tree we're
+/// currently looking at.
 pub struct MenuManager<'a, T> {
     menu: Menu<'a, T>,
     /// Maximum four levels deep
@@ -7,6 +12,9 @@ pub struct MenuManager<'a, T> {
 }
 
 impl<'a, T> MenuManager<'a, T> {
+    /// Create a new MenuManager.
+    ///
+    /// You will be at the top-level.
     pub fn new(menu: Menu<'a, T>) -> Self {
         Self {
             menu,
@@ -14,22 +22,22 @@ impl<'a, T> MenuManager<'a, T> {
         }
     }
 
+    /// How deep into the tree are we?
     pub fn depth(&self) -> usize {
         self.menu_index.iter().take_while(|x| x.is_some()).count()
     }
 
+    /// Go back up to a higher-level menu
     pub fn pop_menu(&mut self) {
-        if let Some(pos) = self
-            .menu_index
-            .iter_mut()
-            .rev()
-            .skip_while(|x| x.is_none())
-            .next()
-        {
+        if let Some(pos) = self.menu_index.iter_mut().rev().find(|x| x.is_some()) {
             pos.take();
         }
     }
 
+    /// Drop into a sub-menu.
+    ///
+    /// The index must be the index of a valid sub-menu, not any other kind of
+    /// item. Do not push too many items.
     pub fn push_menu(&mut self, index: usize) {
         let menu = self.get_menu(None);
         let item = menu.items[index];
@@ -37,15 +45,14 @@ impl<'a, T> MenuManager<'a, T> {
             panic!("Specified index is not a menu");
         }
 
-        let pos = self
-            .menu_index
-            .iter_mut()
-            .skip_while(|x| x.is_some())
-            .next()
-            .unwrap();
+        let pos = self.menu_index.iter_mut().find(|x| x.is_none()).unwrap();
         pos.replace(index);
     }
 
+    /// Get a menu.
+    ///
+    /// Menus are nested. If `depth` is `None`, get the current menu. Otherwise
+    /// if it is `Some(i)` get the menu at depth `i`.
     pub fn get_menu(&self, depth: Option<usize>) -> &Menu<'a, T> {
         let mut menu = &self.menu;
 

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -1,4 +1,4 @@
-use super::{Menu, ItemType};
+use super::{ItemType, Menu};
 
 pub struct MenuManager<'a, T> {
     menu: Menu<'a, T>,
@@ -6,7 +6,7 @@ pub struct MenuManager<'a, T> {
     menu_index: [Option<usize>; 4],
 }
 
-impl <'a, T> MenuManager<'a, T> {
+impl<'a, T> MenuManager<'a, T> {
     pub fn new(menu: Menu<'a, T>) -> Self {
         Self {
             menu,
@@ -19,7 +19,13 @@ impl <'a, T> MenuManager<'a, T> {
     }
 
     pub fn pop_menu(&mut self) {
-        if let Some(pos) = self.menu_index.iter_mut().rev().skip_while(|x| x.is_none()).next() {
+        if let Some(pos) = self
+            .menu_index
+            .iter_mut()
+            .rev()
+            .skip_while(|x| x.is_none())
+            .next()
+        {
             pos.take();
         }
     }
@@ -31,7 +37,12 @@ impl <'a, T> MenuManager<'a, T> {
             panic!("Specified index is not a menu");
         }
 
-        let pos = self.menu_index.iter_mut().skip_while(|x| x.is_some()).next().unwrap();
+        let pos = self
+            .menu_index
+            .iter_mut()
+            .skip_while(|x| x.is_some())
+            .next()
+            .unwrap();
         pos.replace(index);
     }
 
@@ -40,7 +51,13 @@ impl <'a, T> MenuManager<'a, T> {
 
         let depth = depth.unwrap_or_else(|| self.depth());
 
-        for position in self.menu_index.iter().take_while(|x| x.is_some()).map(|x| x.unwrap()).take(depth) {
+        for position in self
+            .menu_index
+            .iter()
+            .take_while(|x| x.is_some())
+            .map(|x| x.unwrap())
+            .take(depth)
+        {
             if let ItemType::Menu(m) = menu.items[position].item_type {
                 menu = m
             } else {
@@ -50,5 +67,4 @@ impl <'a, T> MenuManager<'a, T> {
 
         menu
     }
-
 }


### PR DESCRIPTION
This PR refactors the `Runner` to take ownership of the root menu. This enables the menu to be created on an ad-hoc basis (i.e. not at the crate root) to be handed to the `Runner` without lifetime worries.

The impact is that we can't keep references to the menu internally, so we have to traverse the menu throughout operation. Open to some suggestions.

For an example as to why this is needed, refer to https://github.com/quartiq/stabilizer/pull/813/files#diff-f0b20facc8d3d2dfccda7199e70cb8af5ba9255d80e1d35fdd950dc6a2d567a3R30

I'm trying to build a generic "Serial Console Settings Manager" that uses `menu` for providing the UI for settings management