### PR TITLE
Bump to v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "menu"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Jonathan 'theJPster' Pallant <github@thejpster.org.uk>"]
 description = "A simple #[no_std] command line interface."
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -169,13 +169,17 @@ It contains multiple paragraphs and should be preceeded by the parameter list.
 
 ### Unreleased changes
 
-* Changed the `struct Runner` to own the `struct Menu` instead of borrowing it.
+* None
+
+### v0.4.0
+
+* Changed the `struct Runner` to own the `struct Menu` instead of borrowing it
 * Made `struct Menu` implement `Clone`
 * Add the possibility to disable local echo (via echo feature, enabled by default)
 
 ### v0.3.2
 
-* Shortened help output.
+* Shortened help output
 
 ### v0.3.1
 


### PR DESCRIPTION
* Changed the `struct Runner` to own the `struct Menu` instead of borrowing it
* Made `struct Menu` implement `Clone`
* Add the possibility to disable local echo (via echo feature, enabled by default)