### PR TITLE
Removing ownership of menu context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased](https://github.com/rust-embedded-community/menu/compare/v0.4.0...master)
+
+### Changed
+* [breaking] The `menu` `Context` is now borrowed during I/O input processing to support borrowed data
+* [breaking] The `pub context` item on the runner was updated to `pub interface`
+
+## [v0.4.0] - 2023-09-16
+
+Note: Changes before this version were not tracked via the CHANGELOG
+
+### Changed
+* Changed the struct `Runner` to own the struct `Menu` instead of borrowing it
+
+### Added
+
+* Made struct `Menu` implement `Clone`
+* Add the possibility to disable local echo (via `echo` feature, enabled by default)
+
+[v0.4.0]: https://github.com/rust-embedded-community/menu/releases/tag/v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/rust-embedded-community/menu"
 readme = "README.md"
 
 [dependencies]
-embedded-io = "0.6"
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/rust-embedded-community/menu"
 readme = "README.md"
 
 [dependencies]
+embedded-io = "0.6"
 
 
 [features]

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -4,7 +4,12 @@ use menu::*;
 use pancurses::{endwin, initscr, noecho, Input};
 use std::fmt::Write;
 
-const ROOT_MENU: Menu<Output> = Menu {
+#[derive(Default)]
+struct Context {
+    _data: u32,
+}
+
+const ROOT_MENU: Menu<Output, Context> = Menu {
     label: "root",
     items: &[
         &Item {
@@ -94,21 +99,22 @@ fn main() {
     window.scrollok(true);
     noecho();
     let mut buffer = [0u8; 64];
-    let mut r = Runner::new(ROOT_MENU, &mut buffer, Output(window));
+    let mut context = Context::default();
+    let mut r = Runner::new(ROOT_MENU, &mut buffer, Output(window), &mut context);
     loop {
-        match r.context.0.getch() {
+        match r.interface.0.getch() {
             Some(Input::Character('\n')) => {
-                r.input_byte(b'\r');
+                r.input_byte(b'\r', &mut context);
             }
             Some(Input::Character(c)) => {
                 let mut buf = [0; 4];
                 for b in c.encode_utf8(&mut buf).bytes() {
-                    r.input_byte(b);
+                    r.input_byte(b, &mut context);
                 }
             }
             Some(Input::KeyDC) => break,
             Some(input) => {
-                r.context.0.addstr(&format!("{:?}", input));
+                r.interface.0.addstr(&format!("{:?}", input));
             }
             None => (),
         }
@@ -116,69 +122,88 @@ fn main() {
     endwin();
 }
 
-fn enter_root(_menu: &Menu<Output>, context: &mut Output) {
-    writeln!(context, "In enter_root").unwrap();
+fn enter_root(_menu: &Menu<Output, Context>, _context: &mut Context, interface: &mut Output) {
+    writeln!(interface, "In enter_root").unwrap();
 }
 
-fn exit_root(_menu: &Menu<Output>, context: &mut Output) {
-    writeln!(context, "In exit_root").unwrap();
+fn exit_root(_menu: &Menu<Output, Context>, _context: &mut Context, interface: &mut Output) {
+    writeln!(interface, "In exit_root").unwrap();
 }
 
-fn select_foo<'a>(_menu: &Menu<Output>, item: &Item<Output>, args: &[&str], context: &mut Output) {
-    writeln!(context, "In select_foo. Args = {:?}", args).unwrap();
+fn select_foo(
+    _menu: &Menu<Output, Context>,
+    item: &Item<Output, Context>,
+    args: &[&str],
+    _context: &mut Context,
+    interface: &mut Output,
+) {
+    writeln!(interface, "In select_foo. Args = {:?}", args).unwrap();
     writeln!(
-        context,
+        interface,
         "a = {:?}",
         ::menu::argument_finder(item, args, "a")
     )
     .unwrap();
     writeln!(
-        context,
+        interface,
         "b = {:?}",
         ::menu::argument_finder(item, args, "b")
     )
     .unwrap();
     writeln!(
-        context,
+        interface,
         "verbose = {:?}",
         ::menu::argument_finder(item, args, "verbose")
     )
     .unwrap();
     writeln!(
-        context,
+        interface,
         "level = {:?}",
         ::menu::argument_finder(item, args, "level")
     )
     .unwrap();
     writeln!(
-        context,
+        interface,
         "no_such_arg = {:?}",
         ::menu::argument_finder(item, args, "no_such_arg")
     )
     .unwrap();
 }
 
-fn select_bar<'a>(_menu: &Menu<Output>, _item: &Item<Output>, args: &[&str], context: &mut Output) {
-    writeln!(context, "In select_bar. Args = {:?}", args).unwrap();
-}
-
-fn enter_sub(_menu: &Menu<Output>, context: &mut Output) {
-    writeln!(context, "In enter_sub").unwrap();
-}
-
-fn exit_sub(_menu: &Menu<Output>, context: &mut Output) {
-    writeln!(context, "In exit_sub").unwrap();
-}
-
-fn select_baz<'a>(_menu: &Menu<Output>, _item: &Item<Output>, args: &[&str], context: &mut Output) {
-    writeln!(context, "In select_baz: Args = {:?}", args).unwrap();
-}
-
-fn select_quux<'a>(
-    _menu: &Menu<Output>,
-    _item: &Item<Output>,
+fn select_bar(
+    _menu: &Menu<Output, Context>,
+    _item: &Item<Output, Context>,
     args: &[&str],
-    context: &mut Output,
+    _context: &mut Context,
+    interface: &mut Output,
 ) {
-    writeln!(context, "In select_quux: Args = {:?}", args).unwrap();
+    writeln!(interface, "In select_bar. Args = {:?}", args).unwrap();
+}
+
+fn enter_sub(_menu: &Menu<Output, Context>, _context: &mut Context, interface: &mut Output) {
+    writeln!(interface, "In enter_sub").unwrap();
+}
+
+fn exit_sub(_menu: &Menu<Output, Context>, _context: &mut Context, interface: &mut Output) {
+    writeln!(interface, "In exit_sub").unwrap();
+}
+
+fn select_baz(
+    _menu: &Menu<Output, Context>,
+    _item: &Item<Output, Context>,
+    args: &[&str],
+    _context: &mut Context,
+    interface: &mut Output,
+) {
+    writeln!(interface, "In select_baz: Args = {:?}", args).unwrap();
+}
+
+fn select_quux(
+    _menu: &Menu<Output, Context>,
+    _item: &Item<Output, Context>,
+    args: &[&str],
+    _context: &mut Context,
+    interface: &mut Output,
+) {
+    writeln!(interface, "In select_quux: Args = {:?}", args).unwrap();
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -6,7 +6,7 @@ use std::fmt::Write;
 
 #[derive(Default)]
 struct Context {
-    _data: u32,
+    _inner: u32,
 }
 
 const ROOT_MENU: Menu<Output, Context> = Menu {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,11 +1,15 @@
 extern crate menu;
 
-use embedded_io::Write;
-
 use menu::*;
 use pancurses::{endwin, initscr, noecho, Input};
+use std::fmt::Write;
 
-const ROOT_MENU: Menu<Output> = Menu {
+#[derive(Default)]
+struct Context {
+    _inner: u32,
+}
+
+const ROOT_MENU: Menu<Output, Context> = Menu {
     label: "root",
     items: &[
         &Item {
@@ -81,37 +85,11 @@ It contains multiple paragraphs and should be preceeded by the parameter list.
     exit: Some(exit_root),
 };
 
-struct Output {
-    window: pancurses::Window,
-    input: Vec<u8>,
-}
+struct Output(pancurses::Window);
 
-impl embedded_io::ErrorType for Output {
-    type Error = core::convert::Infallible;
-}
-
-impl embedded_io::ReadReady for Output {
-    fn read_ready(&mut self) -> Result<bool, Self::Error> {
-        Ok(!self.input.is_empty())
-    }
-}
-
-impl embedded_io::Read for Output {
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-        let len = (&self.input[..]).read(buf).unwrap();
-        self.input.drain(..len);
-        Ok(len)
-    }
-}
-
-impl embedded_io::Write for Output {
-    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        let string = String::from_utf8(buf.to_vec()).unwrap();
-        self.window.printw(string);
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> Result<(), Self::Error> {
+impl std::fmt::Write for Output {
+    fn write_str(&mut self, s: &str) -> Result<(), std::fmt::Error> {
+        self.0.printw(s);
         Ok(())
     }
 }
@@ -121,94 +99,111 @@ fn main() {
     window.scrollok(true);
     noecho();
     let mut buffer = [0u8; 64];
-    let mut context = Output {
-        window,
-        input: Vec::new(),
-    };
-    let mut r = Runner::new(ROOT_MENU, &mut buffer, &mut context);
+    let mut context = Context::default();
+    let mut r = Runner::new(ROOT_MENU, &mut buffer, Output(window), &mut context);
     loop {
-        match context.window.getch() {
+        match r.interface.0.getch() {
             Some(Input::Character('\n')) => {
-                context.input.push(b'\r');
+                r.input_byte(b'\r', &mut context);
             }
             Some(Input::Character(c)) => {
                 let mut buf = [0; 4];
-                context
-                    .input
-                    .extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
-                r.process(&mut context);
+                for b in c.encode_utf8(&mut buf).bytes() {
+                    r.input_byte(b, &mut context);
+                }
             }
             Some(Input::KeyDC) => break,
             Some(input) => {
-                context
-                    .input
-                    .extend_from_slice(format!("{:?}", input).as_bytes());
+                r.interface.0.addstr(&format!("{:?}", input));
             }
             None => (),
         }
-        r.process(&mut context);
     }
     endwin();
 }
 
-fn enter_root(_menu: &Menu<Output>, context: &mut Output) {
-    writeln!(context, "In enter_root").unwrap();
+fn enter_root(_menu: &Menu<Output, Context>, _context: &mut Context, interface: &mut Output) {
+    writeln!(interface, "In enter_root").unwrap();
 }
 
-fn exit_root(_menu: &Menu<Output>, context: &mut Output) {
-    writeln!(context, "In exit_root").unwrap();
+fn exit_root(_menu: &Menu<Output, Context>, _context: &mut Context, interface: &mut Output) {
+    writeln!(interface, "In exit_root").unwrap();
 }
 
-fn select_foo(_menu: &Menu<Output>, item: &Item<Output>, args: &[&str], context: &mut Output) {
-    writeln!(context, "In select_foo. Args = {:?}", args).unwrap();
+fn select_foo(
+    _menu: &Menu<Output, Context>,
+    item: &Item<Output, Context>,
+    args: &[&str],
+    _context: &mut Context,
+    interface: &mut Output,
+) {
+    writeln!(interface, "In select_foo. Args = {:?}", args).unwrap();
     writeln!(
-        context,
+        interface,
         "a = {:?}",
         ::menu::argument_finder(item, args, "a")
     )
     .unwrap();
     writeln!(
-        context,
+        interface,
         "b = {:?}",
         ::menu::argument_finder(item, args, "b")
     )
     .unwrap();
     writeln!(
-        context,
+        interface,
         "verbose = {:?}",
         ::menu::argument_finder(item, args, "verbose")
     )
     .unwrap();
     writeln!(
-        context,
+        interface,
         "level = {:?}",
         ::menu::argument_finder(item, args, "level")
     )
     .unwrap();
     writeln!(
-        context,
+        interface,
         "no_such_arg = {:?}",
         ::menu::argument_finder(item, args, "no_such_arg")
     )
     .unwrap();
 }
 
-fn select_bar(_menu: &Menu<Output>, _item: &Item<Output>, args: &[&str], context: &mut Output) {
-    writeln!(context, "In select_bar. Args = {:?}", args).unwrap();
+fn select_bar(
+    _menu: &Menu<Output, Context>,
+    _item: &Item<Output, Context>,
+    args: &[&str],
+    _context: &mut Context,
+    interface: &mut Output,
+) {
+    writeln!(interface, "In select_bar. Args = {:?}", args).unwrap();
 }
 
-fn enter_sub(_menu: &Menu<Output>, context: &mut Output) {
-    writeln!(context, "In enter_sub").unwrap();
+fn enter_sub(_menu: &Menu<Output, Context>, _context: &mut Context, interface: &mut Output) {
+    writeln!(interface, "In enter_sub").unwrap();
 }
 
-fn exit_sub(_menu: &Menu<Output>, context: &mut Output) {
-    writeln!(context, "In exit_sub").unwrap();
+fn exit_sub(_menu: &Menu<Output, Context>, _context: &mut Context, interface: &mut Output) {
+    writeln!(interface, "In exit_sub").unwrap();
 }
 
-fn select_baz(_menu: &Menu<Output>, _item: &Item<Output>, args: &[&str], context: &mut Output) {
-    writeln!(context, "In select_baz: Args = {:?}", args).unwrap();
+fn select_baz(
+    _menu: &Menu<Output, Context>,
+    _item: &Item<Output, Context>,
+    args: &[&str],
+    _context: &mut Context,
+    interface: &mut Output,
+) {
+    writeln!(interface, "In select_baz: Args = {:?}", args).unwrap();
 }
 
-fn select_quux(_menu: &Menu<Output>, _item: &Item<Output>, args: &[&str], context: &mut Output) {
-    writeln!(context, "In select_quux: Args = {:?}", args).unwrap();
+fn select_quux(
+    _menu: &Menu<Output, Context>,
+    _item: &Item<Output, Context>,
+    args: &[&str],
+    _context: &mut Context,
+    interface: &mut Output,
+) {
+    writeln!(interface, "In select_quux: Args = {:?}", args).unwrap();
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -122,11 +122,11 @@ fn main() {
     endwin();
 }
 
-fn enter_root(_menu: &Menu<Output, Context>, _context: &mut Context, interface: &mut Output) {
+fn enter_root(_menu: &Menu<Output, Context>, interface: &mut Output, _context: &mut Context) {
     writeln!(interface, "In enter_root").unwrap();
 }
 
-fn exit_root(_menu: &Menu<Output, Context>, _context: &mut Context, interface: &mut Output) {
+fn exit_root(_menu: &Menu<Output, Context>, interface: &mut Output, _context: &mut Context) {
     writeln!(interface, "In exit_root").unwrap();
 }
 
@@ -134,8 +134,8 @@ fn select_foo(
     _menu: &Menu<Output, Context>,
     item: &Item<Output, Context>,
     args: &[&str],
-    _context: &mut Context,
     interface: &mut Output,
+    _context: &mut Context,
 ) {
     writeln!(interface, "In select_foo. Args = {:?}", args).unwrap();
     writeln!(
@@ -174,17 +174,17 @@ fn select_bar(
     _menu: &Menu<Output, Context>,
     _item: &Item<Output, Context>,
     args: &[&str],
-    _context: &mut Context,
     interface: &mut Output,
+    _context: &mut Context,
 ) {
     writeln!(interface, "In select_bar. Args = {:?}", args).unwrap();
 }
 
-fn enter_sub(_menu: &Menu<Output, Context>, _context: &mut Context, interface: &mut Output) {
+fn enter_sub(_menu: &Menu<Output, Context>, interface: &mut Output, _context: &mut Context) {
     writeln!(interface, "In enter_sub").unwrap();
 }
 
-fn exit_sub(_menu: &Menu<Output, Context>, _context: &mut Context, interface: &mut Output) {
+fn exit_sub(_menu: &Menu<Output, Context>, interface: &mut Output, _context: &mut Context) {
     writeln!(interface, "In exit_sub").unwrap();
 }
 
@@ -192,8 +192,8 @@ fn select_baz(
     _menu: &Menu<Output, Context>,
     _item: &Item<Output, Context>,
     args: &[&str],
-    _context: &mut Context,
     interface: &mut Output,
+    _context: &mut Context,
 ) {
     writeln!(interface, "In select_baz: Args = {:?}", args).unwrap();
 }
@@ -202,8 +202,8 @@ fn select_quux(
     _menu: &Menu<Output, Context>,
     _item: &Item<Output, Context>,
     args: &[&str],
-    _context: &mut Context,
     interface: &mut Output,
+    _context: &mut Context,
 ) {
     writeln!(interface, "In select_quux: Args = {:?}", args).unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,9 +250,13 @@ where
     T: embedded_io::Write + embedded_io::Read + embedded_io::ReadReady,
 {
     /// Create a new `Runner`. You need to supply a top-level menu, and a
-    /// buffer that the `Runner` can use. Feel free to pass anything as the
-    /// `context` type - the only requirement is that the `Runner` can
-    /// `write!` to the context, which it will do for all text output.
+    /// buffer that the `Runner` can use.
+    ///
+    /// The `context` parameter is used for handling I/O of the menu. It must implement the
+    /// respective [`embedded-io`] traits to enable the menu to process input and output.
+    ///
+    /// The `context` is also passed to menu callback functions, so it can be used for maintaining
+    /// state of anything that the menu may control as well.
     pub fn new(menu: Menu<'a, T>, buffer: &'a mut [u8], context: &mut T) -> Self {
         if let Some(cb_fn) = menu.entry {
             cb_fn(&menu, context);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,13 +250,9 @@ where
     T: embedded_io::Write + embedded_io::Read + embedded_io::ReadReady,
 {
     /// Create a new `Runner`. You need to supply a top-level menu, and a
-    /// buffer that the `Runner` can use.
-    ///
-    /// The `context` parameter is used for handling I/O of the menu. It must implement the
-    /// respective [`embedded-io`] traits to enable the menu to process input and output.
-    ///
-    /// The `context` is also passed to menu callback functions, so it can be used for maintaining
-    /// state of anything that the menu may control as well.
+    /// buffer that the `Runner` can use. Feel free to pass anything as the
+    /// `context` type - the only requirement is that the `Runner` can
+    /// `write!` to the context, which it will do for all text output.
     pub fn new(menu: Menu<'a, T>, buffer: &'a mut [u8], context: &mut T) -> Self {
         if let Some(cb_fn) = menu.entry {
             cb_fn(&menu, context);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -675,7 +675,7 @@ mod tests {
         _item: &Item<(), u32>,
         _args: &[&str],
         _context: &mut u32,
-        _interface: (),
+        _interface: &mut (),
     ) {
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,11 @@
 pub mod menu_manager;
 
 /// The type of function we call when we enter/exit a menu.
-pub type MenuCallbackFn<I, T> = fn(menu: &Menu<I, T>, context: &mut T, interface: &mut I);
+pub type MenuCallbackFn<I, T> = fn(menu: &Menu<I, T>, interface: &mut I, context: &mut T);
 
 /// The type of function we call when we a valid command has been entered.
 pub type ItemCallbackFn<I, T> =
-    fn(menu: &Menu<I, T>, item: &Item<I, T>, args: &[&str], context: &mut T, interface: &mut I);
+    fn(menu: &Menu<I, T>, item: &Item<I, T>, args: &[&str], interface: &mut I, context: &mut T);
 
 #[derive(Debug)]
 /// Describes a parameter to the command
@@ -262,7 +262,7 @@ where
         context: &mut T,
     ) -> Self {
         if let Some(cb_fn) = menu.entry {
-            cb_fn(&menu, context, &mut interface);
+            cb_fn(&menu, &mut interface, context);
         }
         let mut r = Runner {
             menu_mgr: menu_manager::MenuManager::new(menu),
@@ -394,7 +394,7 @@ where
                     }
                 } else if cmd == "exit" && self.menu_mgr.depth() != 0 {
                     if let Some(cb_fn) = menu.exit {
-                        cb_fn(menu, context, &mut self.interface);
+                        cb_fn(menu, &mut self.interface, context);
                     }
                     self.menu_mgr.pop_menu();
                 } else {
@@ -416,7 +416,7 @@ where
                                 ),
                                 ItemType::Menu(_) => {
                                     if let Some(cb_fn) = self.menu_mgr.get_menu(None).entry {
-                                        cb_fn(menu, context, &mut self.interface);
+                                        cb_fn(menu, &mut self.interface, context);
                                     }
                                     self.menu_mgr.push_menu(i);
                                 }
@@ -651,14 +651,14 @@ where
                     parent_menu,
                     item,
                     &argument_buffer[0..argument_count],
-                    context,
                     interface,
+                    context,
                 );
             }
         } else {
             // Definitely no arguments
             if mandatory_parameter_count == 0 {
-                callback_function(parent_menu, item, &[], context, interface);
+                callback_function(parent_menu, item, &[], interface, context);
             } else {
                 writeln!(interface, "Error: Insufficient arguments given").unwrap();
             }
@@ -674,8 +674,8 @@ mod tests {
         _menu: &Menu<(), u32>,
         _item: &Item<(), u32>,
         _args: &[&str],
-        _context: &mut u32,
         _interface: &mut (),
+        _context: &mut u32,
     ) {
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ where
     buffer: &'a mut [u8],
     used: usize,
     menu_mgr: menu_manager::MenuManager<'a, I, T>,
-    interface: I,
+    pub interface: I,
 }
 
 /// Describes the ways in which the API can fail

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,10 +301,11 @@ where
                 #[cfg(not(feature = "echo"))]
                 {
                     // Echo the command
-                    context.write_all(b"\r").unwrap();
-                    context.write_all(&self.buffer[..self.used]).unwrap();
+                    write!(context, "\r").unwrap();
+                    if let Ok(s) = core::str::from_utf8(&self.buffer[0..self.used]) {
+                        write!(context, "{}", s).unwrap();
+                    }
                 }
-
                 // Handle the command
                 self.process_command(context);
                 Outcome::CommandProcessed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,10 @@
 pub mod menu_manager;
 
 /// The type of function we call when we enter/exit a menu.
-pub type MenuCallbackFn<T> = fn(menu: &Menu<T>, context: &mut T);
+pub type MenuCallbackFn<C> = fn(menu: &Menu<C>, context: &mut C);
 
 /// The type of function we call when we a valid command has been entered.
-pub type ItemCallbackFn<T> = fn(menu: &Menu<T>, item: &Item<T>, args: &[&str], context: &mut T);
+pub type ItemCallbackFn<C> = fn(menu: &Menu<C>, item: &Item<C>, args: &[&str], context: &mut C);
 
 #[derive(Debug)]
 /// Describes a parameter to the command
@@ -49,19 +49,19 @@ pub enum Parameter<'a> {
 
 /// Do we enter a sub-menu when this command is entered, or call a specific
 /// function?
-pub enum ItemType<'a, T>
+pub enum ItemType<'a, C>
 where
-    T: 'a,
+    C: 'a,
 {
     /// Call a function when this command is entered
     Callback {
         /// The function to call
-        function: ItemCallbackFn<T>,
+        function: ItemCallbackFn<C>,
         /// The list of parameters for this function. Pass an empty list if there aren't any.
         parameters: &'a [Parameter<'a>],
     },
     /// This item is a sub-menu you can enter
-    Menu(&'a Menu<'a, T>),
+    Menu(&'a Menu<'a, C>),
     /// Internal use only - do not use
     _Dummy,
 }
@@ -69,9 +69,9 @@ where
 /// An `Item` is a what our menus are made from. Each item has a `name` which
 /// you have to enter to select this item. Each item can also have zero or
 /// more parameters, and some optional help text.
-pub struct Item<'a, T>
+pub struct Item<'a, C>
 where
-    T: 'a,
+    C: 'a,
 {
     /// The word you need to enter to activate this item. It is recommended
     /// that you avoid whitespace in this string.
@@ -79,35 +79,35 @@ where
     /// Optional help text. Printed if you enter `help`.
     pub help: Option<&'a str>,
     /// The type of this item - menu, callback, etc.
-    pub item_type: ItemType<'a, T>,
+    pub item_type: ItemType<'a, C>,
 }
 
 /// A `Menu` is made of one or more `Item`s.
-pub struct Menu<'a, T>
+pub struct Menu<'a, C>
 where
-    T: 'a,
+    C: 'a,
 {
     /// Each menu has a label which is visible in the prompt, unless you are
     /// the root menu.
     pub label: &'a str,
     /// A slice of menu items in this menu.
-    pub items: &'a [&'a Item<'a, T>],
+    pub items: &'a [&'a Item<'a, C>],
     /// A function to call when this menu is entered. If this is the root menu, this is called when the runner is created.
-    pub entry: Option<MenuCallbackFn<T>>,
+    pub entry: Option<MenuCallbackFn<C>>,
     /// A function to call when this menu is exited. Never called for the root menu.
-    pub exit: Option<MenuCallbackFn<T>>,
+    pub exit: Option<MenuCallbackFn<C>>,
 }
 
 /// This structure handles the menu. You feed it bytes as they are read from
 /// the console and it executes menu actions when commands are typed in
 /// (followed by Enter).
-pub struct Runner<'a, T>
+pub struct Runner<'a, C>
 where
-    T: embedded_io::Write + embedded_io::Read + embedded_io::ReadReady,
+    C: embedded_io::Write + embedded_io::Read + embedded_io::ReadReady,
 {
     buffer: &'a mut [u8],
     used: usize,
-    menu_mgr: menu_manager::MenuManager<'a, T>,
+    menu_mgr: menu_manager::MenuManager<'a, C>,
 }
 
 /// Describes the ways in which the API can fail
@@ -129,8 +129,8 @@ pub enum Error {
 ///   (and hence doesn't take a value).
 /// * Returns `Err(())` if `parameter_name` was not in `item.parameter_list`
 ///   or `item` wasn't an Item::Callback
-pub fn argument_finder<'a, T>(
-    item: &'a Item<'a, T>,
+pub fn argument_finder<'a, C>(
+    item: &'a Item<'a, C>,
     argument_list: &'a [&'a str],
     name_to_find: &'a str,
 ) -> Result<Option<&'a str>, Error> {
@@ -234,8 +234,8 @@ enum Outcome {
     NeedMore,
 }
 
-impl<'a, T> core::clone::Clone for Menu<'a, T> {
-    fn clone(&self) -> Menu<'a, T> {
+impl<'a, C> core::clone::Clone for Menu<'a, C> {
+    fn clone(&self) -> Menu<'a, C> {
         Menu {
             label: self.label,
             items: self.items,
@@ -245,15 +245,15 @@ impl<'a, T> core::clone::Clone for Menu<'a, T> {
     }
 }
 
-impl<'a, T> Runner<'a, T>
+impl<'a, C> Runner<'a, C>
 where
-    T: embedded_io::Write + embedded_io::Read + embedded_io::ReadReady,
+    C: embedded_io::Write + embedded_io::Read + embedded_io::ReadReady,
 {
     /// Create a new `Runner`. You need to supply a top-level menu, and a
     /// buffer that the `Runner` can use. Feel free to pass anything as the
     /// `context` type - the only requirement is that the `Runner` can
     /// `write!` to the context, which it will do for all text output.
-    pub fn new(menu: Menu<'a, T>, buffer: &'a mut [u8], context: &mut T) -> Self {
+    pub fn new(menu: Menu<'a, C>, buffer: &'a mut [u8], context: &mut C) -> Self {
         if let Some(cb_fn) = menu.entry {
             cb_fn(&menu, context);
         }
@@ -268,7 +268,7 @@ where
 
     /// Print out a new command prompt, including sub-menu names if
     /// applicable.
-    pub fn prompt(&mut self, newline: bool, context: &mut T) {
+    pub fn prompt(&mut self, newline: bool, context: &mut C) {
         if newline {
             writeln!(context).unwrap();
         }
@@ -286,7 +286,7 @@ where
     /// Process input data for command lines.
     ///
     /// By default, an echo feature is enabled to display commands on the terminal.
-    pub fn process(&mut self, context: &mut T) {
+    pub fn process(&mut self, context: &mut C) {
         while context.read_ready().unwrap() {
             let mut input_buf = [0; 1];
             context.read(&mut input_buf).unwrap();
@@ -354,7 +354,7 @@ where
     }
 
     /// Scan the buffer and do the right thing based on its contents.
-    fn process_command(&mut self, context: &mut T) {
+    fn process_command(&mut self, context: &mut C) {
         // Go to the next line, below the prompt
         writeln!(context).unwrap();
         if let Ok(command_line) = core::str::from_utf8(&self.buffer[0..self.used]) {
@@ -447,7 +447,7 @@ where
         }
     }
 
-    fn print_short_help(&mut self, context: &mut T, item: &Item<T>) {
+    fn print_short_help(&mut self, context: &mut C, item: &Item<C>) {
         let mut has_options = false;
         match item.item_type {
             ItemType::Callback { parameters, .. } => {
@@ -484,7 +484,7 @@ where
         writeln!(context).unwrap();
     }
 
-    fn print_long_help(&mut self, context: &mut T, item: &Item<T>) {
+    fn print_long_help(&mut self, context: &mut C, item: &Item<C>) {
         writeln!(context, "SUMMARY:").unwrap();
         match item.item_type {
             ItemType::Callback { parameters, .. } => {
@@ -582,11 +582,11 @@ where
     }
 
     fn call_function(
-        context: &mut T,
-        callback_function: ItemCallbackFn<T>,
+        context: &mut C,
+        callback_function: ItemCallbackFn<C>,
         parameters: &[Parameter],
-        parent_menu: &Menu<T>,
-        item: &Item<T>,
+        parent_menu: &Menu<C>,
+        item: &Item<C>,
         command: &str,
     ) {
         let mandatory_parameter_count = parameters

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,11 +301,10 @@ where
                 #[cfg(not(feature = "echo"))]
                 {
                     // Echo the command
-                    write!(context, "\r").unwrap();
-                    if let Ok(s) = core::str::from_utf8(&self.buffer[0..self.used]) {
-                        write!(context, "{}", s).unwrap();
-                    }
+                    context.write_all(b"\r").unwrap();
+                    context.write_all(&self.buffer[..self.used]).unwrap();
                 }
+
                 // Handle the command
                 self.process_command(context);
                 Outcome::CommandProcessed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,11 @@
 pub mod menu_manager;
 
 /// The type of function we call when we enter/exit a menu.
-pub type MenuCallbackFn<T> = fn(menu: &Menu<T>, context: &mut T);
+pub type MenuCallbackFn<I, T> = fn(menu: &Menu<I, T>, context: &mut T, interface: &mut I);
 
 /// The type of function we call when we a valid command has been entered.
-pub type ItemCallbackFn<T> = fn(menu: &Menu<T>, item: &Item<T>, args: &[&str], context: &mut T);
+pub type ItemCallbackFn<I, T> =
+    fn(menu: &Menu<I, T>, item: &Item<I, T>, args: &[&str], context: &mut T, interface: &mut I);
 
 #[derive(Debug)]
 /// Describes a parameter to the command
@@ -49,19 +50,19 @@ pub enum Parameter<'a> {
 
 /// Do we enter a sub-menu when this command is entered, or call a specific
 /// function?
-pub enum ItemType<'a, T>
+pub enum ItemType<'a, I, T>
 where
     T: 'a,
 {
     /// Call a function when this command is entered
     Callback {
         /// The function to call
-        function: ItemCallbackFn<T>,
+        function: ItemCallbackFn<I, T>,
         /// The list of parameters for this function. Pass an empty list if there aren't any.
         parameters: &'a [Parameter<'a>],
     },
     /// This item is a sub-menu you can enter
-    Menu(&'a Menu<'a, T>),
+    Menu(&'a Menu<'a, I, T>),
     /// Internal use only - do not use
     _Dummy,
 }
@@ -69,7 +70,7 @@ where
 /// An `Item` is a what our menus are made from. Each item has a `name` which
 /// you have to enter to select this item. Each item can also have zero or
 /// more parameters, and some optional help text.
-pub struct Item<'a, T>
+pub struct Item<'a, I, T>
 where
     T: 'a,
 {
@@ -79,11 +80,11 @@ where
     /// Optional help text. Printed if you enter `help`.
     pub help: Option<&'a str>,
     /// The type of this item - menu, callback, etc.
-    pub item_type: ItemType<'a, T>,
+    pub item_type: ItemType<'a, I, T>,
 }
 
 /// A `Menu` is made of one or more `Item`s.
-pub struct Menu<'a, T>
+pub struct Menu<'a, I, T>
 where
     T: 'a,
 {
@@ -91,27 +92,24 @@ where
     /// the root menu.
     pub label: &'a str,
     /// A slice of menu items in this menu.
-    pub items: &'a [&'a Item<'a, T>],
+    pub items: &'a [&'a Item<'a, I, T>],
     /// A function to call when this menu is entered. If this is the root menu, this is called when the runner is created.
-    pub entry: Option<MenuCallbackFn<T>>,
+    pub entry: Option<MenuCallbackFn<I, T>>,
     /// A function to call when this menu is exited. Never called for the root menu.
-    pub exit: Option<MenuCallbackFn<T>>,
+    pub exit: Option<MenuCallbackFn<I, T>>,
 }
 
 /// This structure handles the menu. You feed it bytes as they are read from
 /// the console and it executes menu actions when commands are typed in
 /// (followed by Enter).
-pub struct Runner<'a, T>
+pub struct Runner<'a, I, T>
 where
-    T: core::fmt::Write,
-    T: 'a,
+    I: core::fmt::Write,
 {
     buffer: &'a mut [u8],
     used: usize,
-    menu_mgr: menu_manager::MenuManager<'a, T>,
-
-    /// The context object the `Runner` carries around.
-    pub context: T,
+    menu_mgr: menu_manager::MenuManager<'a, I, T>,
+    interface: I,
 }
 
 /// Describes the ways in which the API can fail
@@ -133,8 +131,8 @@ pub enum Error {
 ///   (and hence doesn't take a value).
 /// * Returns `Err(())` if `parameter_name` was not in `item.parameter_list`
 ///   or `item` wasn't an Item::Callback
-pub fn argument_finder<'a, T>(
-    item: &'a Item<'a, T>,
+pub fn argument_finder<'a, I, T>(
+    item: &'a Item<'a, I, T>,
     argument_list: &'a [&'a str],
     name_to_find: &'a str,
 ) -> Result<Option<&'a str>, Error> {
@@ -238,8 +236,8 @@ enum Outcome {
     NeedMore,
 }
 
-impl<'a, T> core::clone::Clone for Menu<'a, T> {
-    fn clone(&self) -> Menu<'a, T> {
+impl<'a, I, T> core::clone::Clone for Menu<'a, I, T> {
+    fn clone(&self) -> Menu<'a, I, T> {
         Menu {
             label: self.label,
             items: self.items,
@@ -249,23 +247,28 @@ impl<'a, T> core::clone::Clone for Menu<'a, T> {
     }
 }
 
-impl<'a, T> Runner<'a, T>
+impl<'a, I, T> Runner<'a, I, T>
 where
-    T: core::fmt::Write,
+    I: core::fmt::Write,
 {
     /// Create a new `Runner`. You need to supply a top-level menu, and a
     /// buffer that the `Runner` can use. Feel free to pass anything as the
     /// `context` type - the only requirement is that the `Runner` can
     /// `write!` to the context, which it will do for all text output.
-    pub fn new(menu: Menu<'a, T>, buffer: &'a mut [u8], mut context: T) -> Runner<'a, T> {
+    pub fn new(
+        menu: Menu<'a, I, T>,
+        buffer: &'a mut [u8],
+        mut interface: I,
+        context: &mut T,
+    ) -> Self {
         if let Some(cb_fn) = menu.entry {
-            cb_fn(&menu, &mut context);
+            cb_fn(&menu, context, &mut interface);
         }
         let mut r = Runner {
             menu_mgr: menu_manager::MenuManager::new(menu),
             buffer,
             used: 0,
-            context,
+            interface,
         };
         r.prompt(true);
         r
@@ -275,24 +278,24 @@ where
     /// applicable.
     pub fn prompt(&mut self, newline: bool) {
         if newline {
-            writeln!(self.context).unwrap();
+            writeln!(self.interface).unwrap();
         }
         for i in 0..self.menu_mgr.depth() {
             if i > 1 {
-                write!(self.context, "/").unwrap();
+                write!(self.interface, "/").unwrap();
             }
 
             let menu = self.menu_mgr.get_menu(Some(i));
-            write!(self.context, "/{}", menu.label).unwrap();
+            write!(self.interface, "/{}", menu.label).unwrap();
         }
-        write!(self.context, "> ").unwrap();
+        write!(self.interface, "> ").unwrap();
     }
 
     /// Add a byte to the menu runner's buffer. If this byte is a
     /// carriage-return, the buffer is scanned and the appropriate action
     /// performed.
     /// By default, an echo feature is enabled to display commands on the terminal.
-    pub fn input_byte(&mut self, input: u8) {
+    pub fn input_byte(&mut self, input: u8, context: &mut T) {
         // Strip carriage returns
         if input == 0x0A {
             return;
@@ -301,18 +304,18 @@ where
             #[cfg(not(feature = "echo"))]
             {
                 // Echo the command
-                write!(self.context, "\r").unwrap();
+                write!(self.interface, "\r").unwrap();
                 if let Ok(s) = core::str::from_utf8(&self.buffer[0..self.used]) {
-                    write!(self.context, "{}", s).unwrap();
+                    write!(self.interface, "{}", s).unwrap();
                 }
             }
             // Handle the command
-            self.process_command();
+            self.process_command(context);
             Outcome::CommandProcessed
         } else if (input == 0x08) || (input == 0x7F) {
             // Handling backspace or delete
             if self.used > 0 {
-                write!(self.context, "\u{0008} \u{0008}").unwrap();
+                write!(self.interface, "\u{0008} \u{0008}").unwrap();
                 self.used -= 1;
             }
             Outcome::NeedMore
@@ -329,17 +332,17 @@ where
                 let valid = core::str::from_utf8(&self.buffer[0..self.used]).is_ok();
                 // Now we've released the buffer, we can draw the prompt
                 if valid {
-                    write!(self.context, "\r").unwrap();
+                    write!(self.interface, "\r").unwrap();
                     self.prompt(false);
                 }
                 // Grab the buffer again to render it to the screen
                 if let Ok(s) = core::str::from_utf8(&self.buffer[0..self.used]) {
-                    write!(self.context, "{}", s).unwrap();
+                    write!(self.interface, "{}", s).unwrap();
                 }
             }
             Outcome::NeedMore
         } else {
-            writeln!(self.context, "Buffer overflow!").unwrap();
+            writeln!(self.interface, "Buffer overflow!").unwrap();
             Outcome::NeedMore
         };
         match outcome {
@@ -352,9 +355,9 @@ where
     }
 
     /// Scan the buffer and do the right thing based on its contents.
-    fn process_command(&mut self) {
+    fn process_command(&mut self, context: &mut T) {
         // Go to the next line, below the prompt
-        writeln!(self.context).unwrap();
+        writeln!(self.interface).unwrap();
         if let Ok(command_line) = core::str::from_utf8(&self.buffer[0..self.used]) {
             // We have a valid string
             let mut parts = command_line.split_whitespace();
@@ -367,11 +370,11 @@ where
                                 self.print_long_help(item);
                             }
                             None => {
-                                writeln!(self.context, "I can't help with {:?}", arg).unwrap();
+                                writeln!(self.interface, "I can't help with {:?}", arg).unwrap();
                             }
                         },
                         _ => {
-                            writeln!(self.context, "AVAILABLE ITEMS:").unwrap();
+                            writeln!(self.interface, "AVAILABLE ITEMS:").unwrap();
                             for item in menu.items {
                                 self.print_short_help(item);
                             }
@@ -391,7 +394,7 @@ where
                     }
                 } else if cmd == "exit" && self.menu_mgr.depth() != 0 {
                     if let Some(cb_fn) = menu.exit {
-                        cb_fn(menu, &mut self.context);
+                        cb_fn(menu, context, &mut self.interface);
                     }
                     self.menu_mgr.pop_menu();
                 } else {
@@ -403,7 +406,8 @@ where
                                     function,
                                     parameters,
                                 } => Self::call_function(
-                                    &mut self.context,
+                                    &mut self.interface,
+                                    context,
                                     function,
                                     parameters,
                                     menu,
@@ -412,7 +416,7 @@ where
                                 ),
                                 ItemType::Menu(_) => {
                                     if let Some(cb_fn) = self.menu_mgr.get_menu(None).entry {
-                                        cb_fn(menu, &mut self.context);
+                                        cb_fn(menu, context, &mut self.interface);
                                     }
                                     self.menu_mgr.push_menu(i);
                                 }
@@ -425,31 +429,32 @@ where
                         }
                     }
                     if !found {
-                        writeln!(self.context, "Command {:?} not found. Try 'help'.", cmd).unwrap();
+                        writeln!(self.interface, "Command {:?} not found. Try 'help'.", cmd)
+                            .unwrap();
                     }
                 }
             } else {
-                writeln!(self.context, "Input was empty?").unwrap();
+                writeln!(self.interface, "Input was empty?").unwrap();
             }
         } else {
             // Hmm ..  we did not have a valid string
-            writeln!(self.context, "Input was not valid UTF-8").unwrap();
+            writeln!(self.interface, "Input was not valid UTF-8").unwrap();
         }
     }
 
-    fn print_short_help(&mut self, item: &Item<T>) {
+    fn print_short_help(&mut self, item: &Item<I, T>) {
         let mut has_options = false;
         match item.item_type {
             ItemType::Callback { parameters, .. } => {
-                write!(self.context, "  {}", item.command).unwrap();
+                write!(self.interface, "  {}", item.command).unwrap();
                 if !parameters.is_empty() {
                     for param in parameters.iter() {
                         match param {
                             Parameter::Mandatory { parameter_name, .. } => {
-                                write!(self.context, " <{}>", parameter_name).unwrap();
+                                write!(self.interface, " <{}>", parameter_name).unwrap();
                             }
                             Parameter::Optional { parameter_name, .. } => {
-                                write!(self.context, " [ <{}> ]", parameter_name).unwrap();
+                                write!(self.interface, " [ <{}> ]", parameter_name).unwrap();
                             }
                             Parameter::Named { .. } => {
                                 has_options = true;
@@ -462,46 +467,50 @@ where
                 }
             }
             ItemType::Menu(_menu) => {
-                write!(self.context, "  {}", item.command).unwrap();
+                write!(self.interface, "  {}", item.command).unwrap();
             }
             ItemType::_Dummy => {
-                write!(self.context, "  {}", item.command).unwrap();
+                write!(self.interface, "  {}", item.command).unwrap();
             }
         }
         if has_options {
-            write!(self.context, " [OPTIONS...]").unwrap();
+            write!(self.interface, " [OPTIONS...]").unwrap();
         }
-        writeln!(self.context).unwrap();
+        writeln!(self.interface).unwrap();
     }
 
-    fn print_long_help(&mut self, item: &Item<T>) {
-        writeln!(self.context, "SUMMARY:").unwrap();
+    fn print_long_help(&mut self, item: &Item<I, T>) {
+        writeln!(self.interface, "SUMMARY:").unwrap();
         match item.item_type {
             ItemType::Callback { parameters, .. } => {
-                write!(self.context, "  {}", item.command).unwrap();
+                write!(self.interface, "  {}", item.command).unwrap();
                 if !parameters.is_empty() {
                     for param in parameters.iter() {
                         match param {
                             Parameter::Mandatory { parameter_name, .. } => {
-                                write!(self.context, " <{}>", parameter_name).unwrap();
+                                write!(self.interface, " <{}>", parameter_name).unwrap();
                             }
                             Parameter::Optional { parameter_name, .. } => {
-                                write!(self.context, " [ <{}> ]", parameter_name).unwrap();
+                                write!(self.interface, " [ <{}> ]", parameter_name).unwrap();
                             }
                             Parameter::Named { parameter_name, .. } => {
-                                write!(self.context, " [ --{} ]", parameter_name).unwrap();
+                                write!(self.interface, " [ --{} ]", parameter_name).unwrap();
                             }
                             Parameter::NamedValue {
                                 parameter_name,
                                 argument_name,
                                 ..
                             } => {
-                                write!(self.context, " [ --{}={} ]", parameter_name, argument_name)
-                                    .unwrap();
+                                write!(
+                                    self.interface,
+                                    " [ --{}={} ]",
+                                    parameter_name, argument_name
+                                )
+                                .unwrap();
                             }
                         }
                     }
-                    writeln!(self.context, "\n\nPARAMETERS:").unwrap();
+                    writeln!(self.interface, "\n\nPARAMETERS:").unwrap();
                     let default_help = "Undocumented option";
                     for param in parameters.iter() {
                         match param {
@@ -510,7 +519,7 @@ where
                                 help,
                             } => {
                                 writeln!(
-                                    self.context,
+                                    self.interface,
                                     "  <{0}>\n    {1}\n",
                                     parameter_name,
                                     help.unwrap_or(default_help),
@@ -522,7 +531,7 @@ where
                                 help,
                             } => {
                                 writeln!(
-                                    self.context,
+                                    self.interface,
                                     "  <{0}>\n    {1}\n",
                                     parameter_name,
                                     help.unwrap_or(default_help),
@@ -534,7 +543,7 @@ where
                                 help,
                             } => {
                                 writeln!(
-                                    self.context,
+                                    self.interface,
                                     "  --{0}\n    {1}\n",
                                     parameter_name,
                                     help.unwrap_or(default_help),
@@ -547,7 +556,7 @@ where
                                 help,
                             } => {
                                 writeln!(
-                                    self.context,
+                                    self.interface,
                                     "  --{0}={1}\n    {2}\n",
                                     parameter_name,
                                     argument_name,
@@ -560,23 +569,24 @@ where
                 }
             }
             ItemType::Menu(_menu) => {
-                write!(self.context, "  {}", item.command).unwrap();
+                write!(self.interface, "  {}", item.command).unwrap();
             }
             ItemType::_Dummy => {
-                write!(self.context, "  {}", item.command).unwrap();
+                write!(self.interface, "  {}", item.command).unwrap();
             }
         }
         if let Some(help) = item.help {
-            writeln!(self.context, "\n\nDESCRIPTION:\n{}", help).unwrap();
+            writeln!(self.interface, "\n\nDESCRIPTION:\n{}", help).unwrap();
         }
     }
 
     fn call_function(
+        interface: &mut I,
         context: &mut T,
-        callback_function: ItemCallbackFn<T>,
+        callback_function: ItemCallbackFn<I, T>,
         parameters: &[Parameter],
-        parent_menu: &Menu<T>,
-        item: &Item<T>,
+        parent_menu: &Menu<I, T>,
+        item: &Item<I, T>,
         command: &str,
     ) {
         let mandatory_parameter_count = parameters
@@ -625,7 +635,7 @@ where
                         }
                     }
                     if !found {
-                        writeln!(context, "Error: Did not understand {:?}", arg).unwrap();
+                        writeln!(interface, "Error: Did not understand {:?}", arg).unwrap();
                         return;
                     }
                 } else {
@@ -633,23 +643,24 @@ where
                 }
             }
             if positional_arguments < mandatory_parameter_count {
-                writeln!(context, "Error: Insufficient arguments given").unwrap();
+                writeln!(interface, "Error: Insufficient arguments given").unwrap();
             } else if positional_arguments > positional_parameter_count {
-                writeln!(context, "Error: Too many arguments given").unwrap();
+                writeln!(interface, "Error: Too many arguments given").unwrap();
             } else {
                 callback_function(
                     parent_menu,
                     item,
                     &argument_buffer[0..argument_count],
                     context,
+                    interface,
                 );
             }
         } else {
             // Definitely no arguments
             if mandatory_parameter_count == 0 {
-                callback_function(parent_menu, item, &[], context);
+                callback_function(parent_menu, item, &[], context, interface);
             } else {
-                writeln!(context, "Error: Insufficient arguments given").unwrap();
+                writeln!(interface, "Error: Insufficient arguments given").unwrap();
             }
         }
     }
@@ -659,7 +670,14 @@ where
 mod tests {
     use super::*;
 
-    fn dummy(_menu: &Menu<u32>, _item: &Item<u32>, _args: &[&str], _context: &mut u32) {}
+    fn dummy(
+        _menu: &Menu<(), u32>,
+        _item: &Item<(), u32>,
+        _args: &[&str],
+        _context: &mut u32,
+        _interface: (),
+    ) {
+    }
 
     #[test]
     fn find_arg_mandatory() {

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -5,17 +5,17 @@ use super::{ItemType, Menu};
 
 /// Holds a nested tree of Menus and remembers which menu within the tree we're
 /// currently looking at.
-pub struct MenuManager<'a, T> {
-    menu: Menu<'a, T>,
+pub struct MenuManager<'a, C> {
+    menu: Menu<'a, C>,
     /// Maximum four levels deep
     menu_index: [Option<usize>; 4],
 }
 
-impl<'a, T> MenuManager<'a, T> {
+impl<'a, C> MenuManager<'a, C> {
     /// Create a new MenuManager.
     ///
     /// You will be at the top-level.
-    pub fn new(menu: Menu<'a, T>) -> Self {
+    pub fn new(menu: Menu<'a, C>) -> Self {
         Self {
             menu,
             menu_index: [None, None, None, None],
@@ -53,7 +53,7 @@ impl<'a, T> MenuManager<'a, T> {
     ///
     /// Menus are nested. If `depth` is `None`, get the current menu. Otherwise
     /// if it is `Some(i)` get the menu at depth `i`.
-    pub fn get_menu(&self, depth: Option<usize>) -> &Menu<'a, T> {
+    pub fn get_menu(&self, depth: Option<usize>) -> &Menu<'a, C> {
         let mut menu = &self.menu;
 
         let depth = depth.unwrap_or_else(|| self.depth());

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -5,17 +5,17 @@ use super::{ItemType, Menu};
 
 /// Holds a nested tree of Menus and remembers which menu within the tree we're
 /// currently looking at.
-pub struct MenuManager<'a, C> {
-    menu: Menu<'a, C>,
+pub struct MenuManager<'a, I, T> {
+    menu: Menu<'a, I, T>,
     /// Maximum four levels deep
     menu_index: [Option<usize>; 4],
 }
 
-impl<'a, C> MenuManager<'a, C> {
+impl<'a, I, T> MenuManager<'a, I, T> {
     /// Create a new MenuManager.
     ///
     /// You will be at the top-level.
-    pub fn new(menu: Menu<'a, C>) -> Self {
+    pub fn new(menu: Menu<'a, I, T>) -> Self {
         Self {
             menu,
             menu_index: [None, None, None, None],
@@ -53,7 +53,7 @@ impl<'a, C> MenuManager<'a, C> {
     ///
     /// Menus are nested. If `depth` is `None`, get the current menu. Otherwise
     /// if it is `Some(i)` get the menu at depth `i`.
-    pub fn get_menu(&self, depth: Option<usize>) -> &Menu<'a, C> {
+    pub fn get_menu(&self, depth: Option<usize>) -> &Menu<'a, I, T> {
         let mut menu = &self.menu;
 
         let depth = depth.unwrap_or_else(|| self.depth());

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -5,17 +5,17 @@ use super::{ItemType, Menu};
 
 /// Holds a nested tree of Menus and remembers which menu within the tree we're
 /// currently looking at.
-pub struct MenuManager<'a, I, T> {
-    menu: Menu<'a, I, T>,
+pub struct MenuManager<'a, C> {
+    menu: Menu<'a, C>,
     /// Maximum four levels deep
     menu_index: [Option<usize>; 4],
 }
 
-impl<'a, I, T> MenuManager<'a, I, T> {
+impl<'a, C> MenuManager<'a, C> {
     /// Create a new MenuManager.
     ///
     /// You will be at the top-level.
-    pub fn new(menu: Menu<'a, I, T>) -> Self {
+    pub fn new(menu: Menu<'a, C>) -> Self {
         Self {
             menu,
             menu_index: [None, None, None, None],
@@ -53,7 +53,7 @@ impl<'a, I, T> MenuManager<'a, I, T> {
     ///
     /// Menus are nested. If `depth` is `None`, get the current menu. Otherwise
     /// if it is `Some(i)` get the menu at depth `i`.
-    pub fn get_menu(&self, depth: Option<usize>) -> &Menu<'a, I, T> {
+    pub fn get_menu(&self, depth: Option<usize>) -> &Menu<'a, C> {
         let mut menu = &self.menu;
 
         let depth = depth.unwrap_or_else(|| self.depth());

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -5,17 +5,17 @@ use super::{ItemType, Menu};
 
 /// Holds a nested tree of Menus and remembers which menu within the tree we're
 /// currently looking at.
-pub struct MenuManager<'a, C> {
-    menu: Menu<'a, C>,
+pub struct MenuManager<'a, T> {
+    menu: Menu<'a, T>,
     /// Maximum four levels deep
     menu_index: [Option<usize>; 4],
 }
 
-impl<'a, C> MenuManager<'a, C> {
+impl<'a, T> MenuManager<'a, T> {
     /// Create a new MenuManager.
     ///
     /// You will be at the top-level.
-    pub fn new(menu: Menu<'a, C>) -> Self {
+    pub fn new(menu: Menu<'a, T>) -> Self {
         Self {
             menu,
             menu_index: [None, None, None, None],
@@ -53,7 +53,7 @@ impl<'a, C> MenuManager<'a, C> {
     ///
     /// Menus are nested. If `depth` is `None`, get the current menu. Otherwise
     /// if it is `Some(i)` get the menu at depth `i`.
-    pub fn get_menu(&self, depth: Option<usize>) -> &Menu<'a, C> {
+    pub fn get_menu(&self, depth: Option<usize>) -> &Menu<'a, T> {
         let mut menu = &self.menu;
 
         let depth = depth.unwrap_or_else(|| self.depth());

--- a/src/menu_manager.rs
+++ b/src/menu_manager.rs
@@ -5,17 +5,17 @@ use super::{ItemType, Menu};
 
 /// Holds a nested tree of Menus and remembers which menu within the tree we're
 /// currently looking at.
-pub struct MenuManager<'a, T> {
-    menu: Menu<'a, T>,
+pub struct MenuManager<'a, I, T> {
+    menu: Menu<'a, I, T>,
     /// Maximum four levels deep
     menu_index: [Option<usize>; 4],
 }
 
-impl<'a, T> MenuManager<'a, T> {
+impl<'a, I, T> MenuManager<'a, I, T> {
     /// Create a new MenuManager.
     ///
     /// You will be at the top-level.
-    pub fn new(menu: Menu<'a, T>) -> Self {
+    pub fn new(menu: Menu<'a, I, T>) -> Self {
         Self {
             menu,
             menu_index: [None, None, None, None],
@@ -53,7 +53,7 @@ impl<'a, T> MenuManager<'a, T> {
     ///
     /// Menus are nested. If `depth` is `None`, get the current menu. Otherwise
     /// if it is `Some(i)` get the menu at depth `i`.
-    pub fn get_menu(&self, depth: Option<usize>) -> &Menu<'a, T> {
+    pub fn get_menu(&self, depth: Option<usize>) -> &Menu<'a, I, T> {
         let mut menu = &self.menu;
 
         let depth = depth.unwrap_or_else(|| self.depth());


### PR DESCRIPTION
This PR fixes #17 by updating the `Context` to no longer be owned by the `Runner`. Instead, an `interface` is owned (to handle I/O) and the context is  borrowed to the runner when IO is being processed.