### PR TITLE
fix: call order for menu entry functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/rust-embedded-community/menu/compare/v0.4.0...master)
 
-* None
+* Fix Menu entry call order
 
 ## [v0.5.0] - 2024-04-26
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ It contains multiple paragraphs and should be preceeded by the parameter list.
 
 ### Unreleased changes
 
-* None
+* Fix Menu entry call order
 
 ### v0.4.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,9 +414,9 @@ where
                                     item,
                                     command_line,
                                 ),
-                                ItemType::Menu(_) => {
-                                    if let Some(cb_fn) = self.menu_mgr.get_menu(None).entry {
-                                        cb_fn(menu, &mut self.interface, context);
+                                ItemType::Menu(incoming_menu) => {
+                                    if let Some(cb_fn) = incoming_menu.entry {
+                                        cb_fn(incoming_menu, &mut self.interface, context);
                                     }
                                     self.menu_mgr.push_menu(i);
                                 }


### PR DESCRIPTION
Hello, 
This pr fixes the menu entry callback order issue, raised in [issue 20](https://github.com/rust-embedded-community/menu/issues/20).
Before the fix, the callbacks are called with this order:
```
enter_root called with root menu as parameter
> sub1
enter_root called with root menu as parameter
/root> sub2
enter_sub1 called with sub1 menu as parameter
/root/sub1> exit
exit_sub2 called with sub2 menu as parameter
/root> exit
exit_sub1 called with sub1 menu as parameter
```
After this pr it looks like this:
```
enter_root called with root menu as parameter
> sub1
enter_sub1 called with sub1 menu as parameter
/root> sub2
enter_sub2 called with sub2 menu as parameter
/root/sub1> exit
exit_sub2 called with sub2 menu as parameter
/root> exit
exit_sub1 called with sub1 menu as parameter
```
Solved it by calling the `ItemType::Menu` member's callback, instead of looking it up from the manager.

For reference here is the menu definition I used to test the fix:
```
const ROOT_MENU: Menu<Output, Context> = Menu {
    label: "root",
    items: &[
        &Item {
            item_type: ItemType::Menu(&Menu {
                label: "sub1",
                items: &[
                    &Item {
                        item_type: ItemType::Menu(&Menu {
                            label: "sub2",
                            items: &[
                            ],
                            entry: Some(enter_sub2),
                            exit: Some(exit_sub2),
                        }),
                        command: "sub2",
                        help: Some("enter sub2-menu"),
                    },
                ],
                entry: Some(enter_sub1),
                exit: Some(exit_sub1),
            }),
            command: "sub1",
            help: Some("enter sub1-menu"),
        },
    ],
    entry: Some(enter_root),
    exit: Some(exit_root),
};
fn enter_root(menu: &Menu<Output, Context>, interface: &mut Output, _context: &mut Context) {
    writeln!(interface, "enter_root called with {} menu as parameter", menu.label).unwrap();
}

fn exit_root(menu: &Menu<Output, Context>, interface: &mut Output, _context: &mut Context) {
    writeln!(interface, "exit_root called with {} menu as parameter", menu.label).unwrap();
}
fn enter_sub1(menu: &Menu<Output, Context>, interface: &mut Output, _context: &mut Context) {
    writeln!(interface, "enter_sub1 called with {} menu as parameter", menu.label).unwrap();
}

fn exit_sub1(menu: &Menu<Output, Context>, interface: &mut Output, _context: &mut Context) {
    writeln!(interface, "exit_sub1 called with {} menu as parameter", menu.label).unwrap();
}
fn enter_sub2(menu: &Menu<Output, Context>, interface: &mut Output, _context: &mut Context) {
    writeln!(interface, "enter_sub2 called with {} menu as parameter", menu.label).unwrap();
}

fn exit_sub2(menu: &Menu<Output, Context>, interface: &mut Output, _context: &mut Context) {
    writeln!(interface, "exit_sub2 called with {} menu as parameter", menu.label).unwrap();
}
```