### PR TITLE
Noline support MVP

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,10 +18,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Build
+    - name: Build (default features)
       run: cargo build
-    - name: Run Tests
+    - name: Build (no features)
+      run: cargo build --no-default-features
+    - name: Build (all features)
+      run: cargo build --all-features
+    - name: Run Tests (default features)
       run: cargo test
+    - name: Run Tests (no features) 
+      run: cargo test --no-default-features
+    - name: Run Tests (all features)
+      run: cargo test --all-features
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,15 @@ repository = "https://github.com/rust-embedded-community/menu"
 readme = "README.md"
 
 [dependencies]
-
+embedded-io = "0.6.1"
+noline = { version = "0.5.0", optional = true }
 
 [features]
 default = ["echo"]
 echo = []
 
 [dev-dependencies]
+noline = { version = "0.5.0", features = ["std"] }
 pancurses = "0.16"
+termion = "4.0.2"
+menu = {path = ".", features = ["noline"]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,9 +280,14 @@ impl<'a, I, T> PromptIter<'a, I, T> {
         let state = if newline {
             PromptIterState::Newline
         } else {
-            PromptIterState::Menu(0)
+            Self::first_menu()
         };
         Self { menu_mgr, state }
+    }
+
+    const fn first_menu() -> PromptIterState {
+        // Skip the first menu level which is root
+        PromptIterState::Menu(1)
     }
 }
 
@@ -293,11 +298,11 @@ impl<'a, I, T> Iterator for PromptIter<'a, I, T> {
         loop {
             match self.state {
                 PromptIterState::Newline => {
-                    self.state = PromptIterState::Menu(0);
+                    self.state = Self::first_menu();
                     break Some("\n");
                 }
                 PromptIterState::Menu(i) => {
-                    if i >= self.menu_mgr.depth() {
+                    if i > self.menu_mgr.depth() {
                         self.state = PromptIterState::Arrow;
                     } else {
                         let menu = self.menu_mgr.get_menu(Some(i));


### PR DESCRIPTION
I've done a quick implementation and got something working. There are some remaining issues that need to be figured out:

- The prompt presents some problems. Noline only supports a static prompt. I tried to see if I can implement a dynamic prompt, but it will require big changes. I looked into supporting any prompt that implements `Display`. That would work with blocking IO, but since we don't have `write_fmt` for `embedded_io_async::Write` it would break async support in `noline`.
- I added `embedded_io`  as dependency and used `Write` from there instead of `core::fmt::Write`.
- I changed `Runner` so that `buffer` is not owned, but instead is an argument to `input_byte`.

#23 