### PR TITLE
Bump to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/rust-embedded-community/menu/compare/v0.5.1...master)
+## [Unreleased](https://github.com/rust-embedded-community/menu/compare/v0.6.0...master)
 
 * None
+
+## [v0.6.0] - 2024-08-30
+
+### Changed
+
+* We now run clippy in CI
+* Add optional support for [`noline`](https://crates.io/crates/noline) as a line-editor with history 
+* The interface we use for reading and writing bytes must now implement the [`embedded-io`](https://crates.io/crates/embedded-io) traits
 
 ## [v0.5.1] - 2024-08-22
 
@@ -63,6 +71,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * First release
 
+[v0.6.0]: https://github.com/rust-embedded-community/menu/releases/tag/v0.6.0
 [v0.5.1]: https://github.com/rust-embedded-community/menu/releases/tag/v0.5.1
 [v0.5.0]: https://github.com/rust-embedded-community/menu/releases/tag/v0.5.0
 [v0.4.0]: https://github.com/rust-embedded-community/menu/releases/tag/v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "menu"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Jonathan 'theJPster' Pallant <github@thejpster.org.uk>"]
 description = "A simple #[no_std] command line interface."
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -165,6 +165,23 @@ It contains multiple paragraphs and should be preceeded by the parameter list.
 
 ```
 
+## Using with `noline`
+
+The [`noline`](https://crates.io/crates/noline) crate is a no-std line-editor
+with history buffer. You can create a `Runner` using a `noline::Editor` instead
+of a raw byte slice, and then you will get a `pub fn input_line(&mut self,
+context: &mut T) -> Result<(), NolineError>` instead of the `pub fn
+input_byte(&mut self, input: u8, context: &mut T)` you get when you pass a
+mutable byte slice and let `menu` do the input handling. Call `input_line` and
+it will use the `noline::Editor` to read a line of text from the user, with
+history (press 'Up'!) and other nice features.
+
+We chose this option as `noline` offers a bunch of benefits, but we didn't want
+to break everything for people who were quite happy with the basic line editing
+we have already.
+
+See [`examples/noline.rs`](./examples/noline.rs) for an example.
+
 ## Changelog
 
 See [`CHANGELOG.md`](./CHANGELOG.md).


### PR DESCRIPTION
Also updates the CHANGELOG to explain what we did.

It's a major bump because we now require embedded-io traits to be implemented.