### PR TITLE
Release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/rust-embedded-community/menu/compare/v0.6.0...master)
+## [Unreleased](https://github.com/rust-embedded-community/menu/compare/v0.6.1...master)
+
+## [v0.6.1] - 2024-11-29
 
 ### Changed
 
@@ -80,6 +82,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * First release
 
+[v0.6.1]: https://github.com/rust-embedded-community/menu/releases/tag/v0.6.1
 [v0.6.0]: https://github.com/rust-embedded-community/menu/releases/tag/v0.6.0
 [v0.5.1]: https://github.com/rust-embedded-community/menu/releases/tag/v0.5.1
 [v0.5.0]: https://github.com/rust-embedded-community/menu/releases/tag/v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,11 +47,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Made `struct Menu` implement `Clone`
 * Add the possibility to disable local echo (via `echo` feature, enabled by default)
 
-## [v0.3.1] - 2019-08-11
+## [v0.3.2] - 2019-08-22
 
 ### Changed
 
-* Updated crate metadata
+* Tidied up help text
+
+## [v0.3.1] - 2019-08-11
+
 
 ## [v0.3.0] - 2019-08-11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "menu"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Jonathan 'theJPster' Pallant <github@thejpster.org.uk>"]
 description = "A simple #[no_std] command line interface."
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@ struct PromptIter<'a, I, T> {
     state: PromptIterState,
 }
 
-impl<'a, I, T> Clone for PromptIter<'a, I, T> {
+impl<I, T> Clone for PromptIter<'_, I, T> {
     fn clone(&self) -> Self {
         Self {
             menu_mgr: self.menu_mgr,
@@ -380,7 +380,7 @@ where
     }
 }
 
-impl<'a, I, T, B> Runner<'a, I, T, B>
+impl<I, T, B> Runner<'_, I, T, B>
 where
     I: embedded_io::Write,
     B: AsMut<[u8]> + ?Sized,
@@ -456,7 +456,7 @@ where
     }
 }
 
-impl<'a, I, T> InnerRunner<'a, I, T>
+impl<I, T> InnerRunner<'_, I, T>
 where
     I: embedded_io::Write,
 {


### PR DESCRIPTION
## [v0.6.1] - 2024-11-29

### Changed

* For `Runner::input_byte` the buffer `B` does not need to be `Sized`

### Added

* `impl core::error::Error for Error` on rust >= 1.81